### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/PubMed.py
+++ b/src/PubMed.py
@@ -52,7 +52,7 @@ class PubMedObject(object):
         if doi_string:
             doi = doi_string.split("doi:")[-1].strip().split(" ")[0][:-1]
             if doi:
-                url = "http://dx.doi.org/%s" % doi
+                url = "https://doi.org/%s" % doi
         else:
             doi_string = self.soup.find(class_="portlet")
             if doi_string:


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!